### PR TITLE
FIX: State handler also must using LaravelSessionStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor/
 .env
 .DS_Store

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -2,6 +2,7 @@
 
 namespace Auth0\Login;
 
+use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Config;
 use Auth0\SDK\API\Authentication;
 use Auth0\SDK\Auth0;
@@ -25,6 +26,7 @@ class Auth0Service
       $this->auth0Config = config('laravel-auth0');
 
       $this->auth0Config['store'] = new LaravelSessionStore();
+      $this->auth0Config['state_handler'] = new SessionStateHandler(new LaravelSessionStore());
 
       $this->authApi = new Authentication($this->auth0Config['domain'], $this->auth0Config['client_id']);
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- config `state_handler` State handler also must using LaravelSessionStore

### References

Please include relevant links supporting this change such as a:

- https://github.com/auth0/laravel-auth0/issues/125


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[x] This change has been tested on the latest version Laravel 5.8

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
